### PR TITLE
Add plugin loader with error handling

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,26 @@
+import importlib
+import logging
+import pkgutil
+
+logger = logging.getLogger(__name__)
+
+
+def load_plugins():
+    """Load available plugin modules.
+
+    Returns a dict mapping plugin names to loaded modules. Any plugin that
+    fails to import will be skipped and a warning will be logged.
+    """
+    loaded = {}
+    for finder, name, ispkg in pkgutil.iter_modules(__path__):
+        full_name = f"{__name__}.{name}"
+        try:
+            module = importlib.import_module(full_name)
+        except Exception as exc:  # catch broad because dependency issues vary
+            logger.warning("Failed to load plugin %s: %s", name, exc)
+            continue
+        loaded[name] = module
+    return loaded
+
+
+__all__ = ["load_plugins"]

--- a/plugins/broken.py
+++ b/plugins/broken.py
@@ -1,0 +1,5 @@
+import importlib
+
+# This plugin depends on a package that does not exist. Importing it will
+# raise ModuleNotFoundError which should be gracefully handled by the loader.
+importlib.import_module('nonexistent_dependency')

--- a/plugins/echo.py
+++ b/plugins/echo.py
@@ -1,0 +1,3 @@
+def echo(text: str) -> str:
+    """Simple plugin that echoes the provided text."""
+    return text

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -1,0 +1,11 @@
+import logging
+import plugins
+
+
+def test_load_plugins_handles_missing_dependencies(caplog):
+    with caplog.at_level(logging.WARNING):
+        loaded = plugins.load_plugins()
+    assert 'echo' in loaded
+    assert 'broken' not in loaded
+    # ensure a warning was logged for the broken plugin
+    assert any('broken' in record.message for record in caplog.records)

--- a/voice_bridge.py
+++ b/voice_bridge.py
@@ -1,8 +1,18 @@
-import speech_recognition as sr
-import pyttsx3
+try:
+    import speech_recognition as sr  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    sr = None
+
+try:
+    import pyttsx3  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pyttsx3 = None
 
 
 def listen_and_repeat():
+    if sr is None or pyttsx3 is None:
+        raise RuntimeError("voice dependencies are not installed")
+
     recognizer = sr.Recognizer()
     engine = pyttsx3.init()
     with sr.Microphone() as source:


### PR DESCRIPTION
## Summary
- add `plugins` package with `load_plugins()` to skip modules whose deps are missing
- add sample plugins (`echo`, `broken`)
- handle missing dependencies gracefully in `voice_bridge`
- test plugin loader behavior when optional deps are absent

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c0fa4d9208329b3b8d3254d5a20ec