### PR TITLE
Add plugin argument to mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Codex-harness
+
+## Usage
+
+Run the mobile app with a specific plugin:
+
+```bash
+python mobile_app.py --plugin myplugin
+```
+
+Replace `myplugin` with the plugin you want to load.

--- a/mobile_app.py
+++ b/mobile_app.py
@@ -4,6 +4,7 @@ from kivy.uix.button import Button
 from kivy.uix.label import Label
 import speech_recognition as sr
 import pyttsx3
+import argparse
 
 
 class VoiceBox(BoxLayout):
@@ -32,9 +33,18 @@ class VoiceBox(BoxLayout):
 
 
 class VoiceApp(App):
+    def __init__(self, plugin="default", **kwargs):
+        super().__init__(**kwargs)
+        self.plugin = plugin
+
     def build(self):
+        print(f"Launching with plugin: {self.plugin}")
         return VoiceBox()
 
 
 if __name__ == '__main__':
-    VoiceApp().run()
+    parser = argparse.ArgumentParser(description='Run the mobile voice app')
+    parser.add_argument('--plugin', default='default',
+                        help='Name of plugin to load')
+    args = parser.parse_args()
+    VoiceApp(plugin=args.plugin).run()


### PR DESCRIPTION
## Summary
- parse `--plugin` argument in `mobile_app.py`
- allow `VoiceApp` to receive plugin name
- document plugin usage in README

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c0faa790083298e2cbfd4cb8a7f47