### PR TITLE
Add plugin loading to VoiceApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ python mobile_app.py --plugin myplugin
 ```
 
 Replace `myplugin` with the plugin you want to load.
-This project demonstrates simple speech recognition and text-to-speech examples written in Python.
+Plugins are discovered at runtime using `plugins.load_plugins()`. If the
+requested plugin cannot be imported, the app continues without it and prints a
+message.
+This project demonstrates simple speech recognition and text-to-speech examples
+written in Python.
 
 ## Installation
 

--- a/mobile_app.py
+++ b/mobile_app.py
@@ -5,6 +5,7 @@ from kivy.uix.label import Label
 import speech_recognition as sr
 import pyttsx3
 import argparse
+from plugins import load_plugins
 
 
 class VoiceBox(BoxLayout):
@@ -36,9 +37,19 @@ class VoiceApp(App):
     def __init__(self, plugin="default", **kwargs):
         super().__init__(**kwargs)
         self.plugin = plugin
+        self.plugin_module = None
 
     def build(self):
         print(f"Launching with plugin: {self.plugin}")
+        available = load_plugins()
+        self.plugin_module = available.get(self.plugin)
+        if self.plugin_module is None:
+            print(f"Plugin '{self.plugin}' not found; continuing without it")
+        else:
+            print(
+                f"Loaded plugin '{self.plugin}' from "
+                f"{self.plugin_module.__name__}"
+            )
         return VoiceBox()
 
 

--- a/test_mobile_app.py
+++ b/test_mobile_app.py
@@ -1,0 +1,13 @@
+import mobile_app
+
+
+def test_voice_app_loads_specified_plugin(monkeypatch):
+    class DummyBox:
+        pass
+
+    monkeypatch.setattr(mobile_app, "VoiceBox", DummyBox)
+    app = mobile_app.VoiceApp(plugin='echo')
+    widget = app.build()
+    assert app.plugin_module is not None
+    assert app.plugin_module.echo('hi') == 'hi'
+    assert isinstance(widget, DummyBox)


### PR DESCRIPTION
## Summary
- allow VoiceApp to load plugins with `plugins.load_plugins()`
- document plugin loading behavior in README
- test that VoiceApp loads the requested plugin module

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c21cb47b88329ac37dfea20700a31